### PR TITLE
[FJD-43] Sitemap configuration for Basic Page

### DIFF
--- a/config/install/xmlsitemap.settings.node.page.yml
+++ b/config/install/xmlsitemap.settings.node.page.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 60

--- a/starterkit.info.yml
+++ b/starterkit.info.yml
@@ -16,6 +16,7 @@ install:
   - checklistapi
   - ckeditor_media_embed
   - coffee
+  - config
   - config_ignore
   - config_split
   - content_moderation


### PR DESCRIPTION
Jira issue: [FJD-43](https://fivejars.atlassian.net/browse/FJD-43)

Steps to review:
- [ ] login as admin
- [ ] add few basic pages
- [ ] go to Configuration > System > Cron (admin/config/system/cron/jobs)
- [ ] run the job XML Sitemap
- [ ] Open http://pr-28.dskit.ci.fivejars.com/sitemap.xml and ensure that links to created nodes appeared there
